### PR TITLE
Fix documentation for copy 'n paste of example

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Helper action to apt-install packages on the local machine (only for use on `ubuntu-latest` runners)
 
 ```yaml
-  - uses: ryankurte/action-apt@v0.1
+  - uses: ryankurte/action-apt@v0.2.0
     with: 
       packages: "libsqlite3-dev"
 ```


### PR DESCRIPTION
Wanted to be lazy and copy 'n pasted the example. Did not work. Fixed the README.md so that others can be more successful in being lazy ;-).