### PR TITLE
Stop using deprecated set-output function

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ runs:
     - name: "Discover distro name"
       id: discover-distro
       shell: bash
-      run: echo "::set-output name=distro::$(lsb_release -cs)"
+      run: echo "distro=$(lsb_release -cs)" >> $GITHUB_OUTPUT
 
     - name: "Add ports.ubuntu.com sources to /etc/apt/sources.list.d/${{ inputs.arch }}.list"
       shell: bash


### PR DESCRIPTION
set-output has been deprecated and will cease to function in the future. Update to the newer recommended $GITHUB_OUTPUT token method.
Ref: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/